### PR TITLE
Add iOS Getting Started Guide

### DIFF
--- a/spec/client/ios/GETTING_STARTED.md
+++ b/spec/client/ios/GETTING_STARTED.md
@@ -1,1 +1,36 @@
-## Getting Started
+# Getting Started - PayPal iOS SDK
+
+Welcome to [PayPal's iOS SDK](https://github.com/paypal/ios-sdk). This library will help you accept card, PayPal, Venmo, and alternative payment methods in your iOS app.
+
+## Support
+
+The PayPal iOS SDK supports a minimum deployment target of iOS 13+ and requires Xcode 13+. See our [Client Deprecation policy](https://developer.paypal.com/braintree/docs/guides/client-sdk/deprecation-policy/ios/v5) to plan for updates.
+
+### Package Managers
+Include the PayPal SDK in your app via:
+
+* [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html)
+* [Swift Package Manager](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app)
+
+### Languages
+
+This SDK supports Swift 5.1+. This SDK is written in Swift.
+
+### UI Frameworks
+This SDK supports:
+
+* UIKit
+* SwiftUI
+
+## Modularity
+
+The PayPal iOS SDK is comprised of various submodules.
+* `Card`
+* `PayPal`
+* ...
+
+To accept a certain payment method in your app, you only need to include that payment-specific submodule.
+
+## Sample Code
+
+<!-- TODO: - link to each component spec docs, once complete (spec/client/ios/components/) -->

--- a/spec/client/ios/GETTING_STARTED.md
+++ b/spec/client/ios/GETTING_STARTED.md
@@ -24,7 +24,7 @@ This SDK supports:
 
 ## Modularity
 
-The PayPal iOS SDK is comprised of various submodules.
+The PayPal iOS SDK is comprised of various submodules:
 * `Card`
 * `PayPal`
 * ...


### PR DESCRIPTION
- This mostly just pulls in details already fleshed out in the iOS-SDK README (https://github.com/paypal/ios-sdk).
- The motivation for this work is to fulfill JIRA DTPPSDK-292.

*Note:*
- Do others share concern about having duplicate information across repos? I don't see a ton of value to adding this to the specs repo, but added it to be consistent to the other platforms.