### PR TITLE
Add getting started guide for js sdk

### DIFF
--- a/spec/client/javascript/GETTING_STARTED.md
+++ b/spec/client/javascript/GETTING_STARTED.md
@@ -1,0 +1,32 @@
+# Getting Started - PayPal JS SDK
+
+Welcome to PayPal's JS SDK getting started guide. Learn how to accept payments on your website using card, PayPal, Venmo, and alternative payment methods.
+
+## Add the SDK script
+
+There are two ways you can integrate the SDK.
+
+1. You can add it in a script tag. After the script is loaded, you can reference `window.paypal` to use the sdk. Replace YOUR_CLIENT_ID with your client ID.
+
+```js
+<script src="https://www.paypal.com/sdk/js?client-id=YOUR_CLIENT_ID"></script>
+```
+
+2. You can use it as a module. The @paypal/sdk library provides a loading wrapper for the JS SDK script so you can easily load it using JavaScript.
+
+```js
+import { loadScript } from "@paypal/sdk";
+
+let paypal;
+
+try {
+  paypal = await loadScript({ clientID: YOUR_CLIENT_ID })
+}
+catch (err) {
+  console.error("failed to load the PayPal JS SDK script", err);
+}
+```
+
+## Sample Code
+
+<!-- TODO: - link to each component spec docs, once complete (spec/client/javascript/components/) -->


### PR DESCRIPTION
First draft at the getting started guide for the JS SDK:

<img width="1089" alt="Screen Shot 2021-08-30 at 3 29 36 PM" src="https://user-images.githubusercontent.com/534034/131401275-5210d925-6522-4b09-acab-4ee1212fe65d.png">
