### PR TITLE
refactor: clarify support section of JS spec as browser support

### DIFF
--- a/spec/client/javascript/standards/README.md
+++ b/spec/client/javascript/standards/README.md
@@ -1,6 +1,6 @@
 # Standards
 
-- [Support](./support.md)
+- [Browser Support](./browser-support.md)
 - [Components](./components.md)
 - [Versioning](./versioning.md)
 - [Accessibility](./accessibility.md)

--- a/spec/client/javascript/standards/browser-support.md
+++ b/spec/client/javascript/standards/browser-support.md
@@ -1,4 +1,4 @@
-# Support
+# Browser Support
 
 - Desktop
   - Chrome version 41 and later
@@ -7,6 +7,7 @@
   - Opera version 12 and later
   - Edge version 14 and later
   - Internet Explorer version 11 and later
+
 - Mobile
   - Chrome version 41 and later
   - Firefox version 15 and later


### PR DESCRIPTION
Just a slight change to clarify that the support section is about documenting browser support, rather than documenting how developer can receive support for working with the SDK.